### PR TITLE
Document clarification round-trip in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,65 @@
-readme
+# Troubleshooting Assistant
+
+This repository hosts a small demo service that accepts user troubleshooting questions through a POST `/chat` endpoint.
+
+## Clarification protocol
+
+The assistant may respond with a `needsClarification` object when it lacks critical system context. The structure of this response is:
+
+```json
+{
+  "needsClarification": {
+    "question": "string"
+  }
+}
+```
+
+`question` contains the clarifying prompt the client must present to the user.
+
+### Client resubmission
+
+When a response contains `needsClarification`, clients must:
+
+1. Present `needsClarification.question` to the user and collect additional information.
+2. Resubmit the original message to `/chat` and include the user's answer in the `clarifiedSystem` field of the request body.
+
+### `/chat` request body
+
+```json
+{
+  "message": "string",
+  "clarifiedSystem": "string (optional)"
+}
+```
+
+`clarifiedSystem` is omitted on the initial request and only supplied after the server asks for clarification.
+
+## Clarification round-trip example
+
+```
+POST /chat
+{ "message": "My printer won't print." }
+
+→ Response:
+{ 
+  "needsClarification": { 
+    "question": "Which operating system are you using?" 
+  } 
+}
+
+# Client collects clarification from the user...
+# User: "I'm on Windows 11"
+
+POST /chat
+{
+  "message": "My printer won't print.",
+  "clarifiedSystem": "User is on Windows 11."
+}
+
+→ Response:
+{
+  "text": "Try reinstalling the Windows 11 printer driver.",
+  "reset": false
+}
+```
+


### PR DESCRIPTION
## Summary
- Describe `needsClarification` response format
- Explain resubmission with `clarifiedSystem`
- Add `/chat` request structure and round-trip example

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a379b83298832faa000b7ddfb69151