### PR TITLE
Use configurable API base path for frontend

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Base URL for API requests
+VITE_API_BASE=http://localhost:3000

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,3 +10,14 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and adjust the values as needed. The app reads the following variable:
+
+```
+VITE_API_BASE=http://localhost:3000
+```
+
+`VITE_API_BASE` sets the base URL for backend requests. When unset, the frontend defaults to sending requests to the same origin using the `/chat` path.
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,8 @@ function App() {
   const [systemOptions, setSystemOptions] = useState([]);
   const messagesEndRef = useRef(null);
 
+  const API_BASE = (import.meta.env.VITE_API_BASE || "").replace(/\/$/, "");
+
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
@@ -19,7 +21,7 @@ function App() {
     setMessages((prev) => [...prev, newUserMessage]);
 
     try {
-      const response = await fetch("http://stiab.online:3000/chat", {
+      const response = await fetch(`${API_BASE}/chat`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message: input, clarifiedSystem }),


### PR DESCRIPTION
## Summary
- Replace hard-coded chat endpoint with `${import.meta.env.VITE_API_BASE}/chat`
- Add `.env.example` and document `VITE_API_BASE` in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b37e8e6cbc832fa84c7d5ed4a3fb98