### PR TITLE
Cache vector store and await initialization

### DIFF
--- a/server.js
+++ b/server.js
@@ -41,8 +41,7 @@ app.get("*", (req, res) => {
   res.sendFile(path.join(__dirname, "frontend/dist", "index.html"));
 });
 
-initStore().then(() => {
-  app.listen(3000, () => {
-    console.log("Assistant backend + frontend running on port 3000");
-  });
+await initStore();
+app.listen(3000, () => {
+  console.log("Assistant backend + frontend running on port 3000");
 });


### PR DESCRIPTION
## Summary
- Initialize the troubleshooting vector store once in `initStore` and cache it for reuse
- Reuse cached vector store in `searchDocs`
- Await `initStore` before starting the server

## Testing
- `node --check troubleshooter.js`
- `node --check server.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b37ea84314832faf6d34831a3621db