### PR TITLE
Use async file operations in admin routes

### DIFF
--- a/adminRoutes.js
+++ b/adminRoutes.js
@@ -1,23 +1,23 @@
 // adminRoutes.js
 import express from "express";
-import fs from "fs";
+import { promises as fs } from "fs";
 const router = express.Router();
 
 const filePath = "./data/troubleshooting.json"; // Use your real path
 
-function readData() {
-  const raw = fs.readFileSync(filePath);
+async function readData() {
+  const raw = await fs.readFile(filePath, "utf-8");
   return JSON.parse(raw);
 }
 
-function writeData(data) {
-  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+async function writeData(data) {
+  await fs.writeFile(filePath, JSON.stringify(data, null, 2));
 }
 
 // Get all entries
-router.get("/entries", (req, res) => {
+router.get("/entries", async (req, res) => {
   try {
-    const data = readData();
+    const data = await readData();
     res.json(data);
   } catch (e) {
     res.status(500).json({ error: "Failed to load entries" });
@@ -25,12 +25,12 @@ router.get("/entries", (req, res) => {
 });
 
 // Add new entry
-router.post("/entries", (req, res) => {
+router.post("/entries", async (req, res) => {
   try {
-    const data = readData();
+    const data = await readData();
     const newEntry = req.body;
     data.push(newEntry);
-    writeData(data);
+    await writeData(data);
     res.status(201).json({ message: "Entry added" });
   } catch (e) {
     res.status(500).json({ error: "Failed to add entry" });
@@ -38,13 +38,13 @@ router.post("/entries", (req, res) => {
 });
 
 // Edit entry by index
-router.put("/entries/:index", (req, res) => {
+router.put("/entries/:index", async (req, res) => {
   try {
-    const data = readData();
+    const data = await readData();
     const idx = parseInt(req.params.index);
     if (idx < 0 || idx >= data.length) return res.status(404).json({ error: "Entry not found" });
     data[idx] = req.body;
-    writeData(data);
+    await writeData(data);
     res.json({ message: "Entry updated" });
   } catch (e) {
     res.status(500).json({ error: "Failed to update entry" });
@@ -52,13 +52,13 @@ router.put("/entries/:index", (req, res) => {
 });
 
 // Delete entry by index
-router.delete("/entries/:index", (req, res) => {
+router.delete("/entries/:index", async (req, res) => {
   try {
-    const data = readData();
+    const data = await readData();
     const idx = parseInt(req.params.index);
     if (idx < 0 || idx >= data.length) return res.status(404).json({ error: "Entry not found" });
     data.splice(idx, 1);
-    writeData(data);
+    await writeData(data);
     res.json({ message: "Entry deleted" });
   } catch (e) {
     res.status(500).json({ error: "Failed to delete entry" });


### PR DESCRIPTION
## Summary
- replace synchronous `fs` reads/writes with `fs.promises` in admin routes
- convert data access helpers and route handlers to async/await with error handling

## Testing
- `node --check adminRoutes.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b40681ffec832f92dec3ae76c6968e