### PR TITLE
Use UUIDs for troubleshooting entries

### DIFF
--- a/adminRoutes.js
+++ b/adminRoutes.js
@@ -1,6 +1,7 @@
 // adminRoutes.js
 import express from "express";
 import fs from "fs";
+import { randomUUID } from "crypto";
 const router = express.Router();
 
 const filePath = "./data/troubleshooting.json"; // Use your real path
@@ -28,38 +29,40 @@ router.get("/entries", (req, res) => {
 router.post("/entries", (req, res) => {
   try {
     const data = readData();
-    const newEntry = req.body;
+    const newEntry = { id: randomUUID(), ...req.body };
     data.push(newEntry);
     writeData(data);
-    res.status(201).json({ message: "Entry added" });
+    res.status(201).json(data);
   } catch (e) {
     res.status(500).json({ error: "Failed to add entry" });
   }
 });
 
-// Edit entry by index
-router.put("/entries/:index", (req, res) => {
+// Edit entry by id
+router.put("/entries/:id", (req, res) => {
   try {
     const data = readData();
-    const idx = parseInt(req.params.index);
-    if (idx < 0 || idx >= data.length) return res.status(404).json({ error: "Entry not found" });
-    data[idx] = req.body;
+    const id = req.params.id;
+    const idx = data.findIndex(entry => entry.id === id);
+    if (idx === -1) return res.status(404).json({ error: "Entry not found" });
+    data[idx] = { ...req.body, id };
     writeData(data);
-    res.json({ message: "Entry updated" });
+    res.json(data);
   } catch (e) {
     res.status(500).json({ error: "Failed to update entry" });
   }
 });
 
-// Delete entry by index
-router.delete("/entries/:index", (req, res) => {
+// Delete entry by id
+router.delete("/entries/:id", (req, res) => {
   try {
     const data = readData();
-    const idx = parseInt(req.params.index);
-    if (idx < 0 || idx >= data.length) return res.status(404).json({ error: "Entry not found" });
+    const id = req.params.id;
+    const idx = data.findIndex(entry => entry.id === id);
+    if (idx === -1) return res.status(404).json({ error: "Entry not found" });
     data.splice(idx, 1);
     writeData(data);
-    res.json({ message: "Entry deleted" });
+    res.json(data);
   } catch (e) {
     res.status(500).json({ error: "Failed to delete entry" });
   }

--- a/adminRoutes.js
+++ b/adminRoutes.js
@@ -32,7 +32,7 @@ router.post("/entries", (req, res) => {
     const newEntry = { id: randomUUID(), ...req.body };
     data.push(newEntry);
     writeData(data);
-    res.status(201).json(data);
+    res.status(201).json(newEntry);
   } catch (e) {
     res.status(500).json({ error: "Failed to add entry" });
   }
@@ -47,7 +47,7 @@ router.put("/entries/:id", (req, res) => {
     if (idx === -1) return res.status(404).json({ error: "Entry not found" });
     data[idx] = { ...req.body, id };
     writeData(data);
-    res.json(data);
+    res.json(data[idx]);
   } catch (e) {
     res.status(500).json({ error: "Failed to update entry" });
   }
@@ -62,7 +62,7 @@ router.delete("/entries/:id", (req, res) => {
     if (idx === -1) return res.status(404).json({ error: "Entry not found" });
     data.splice(idx, 1);
     writeData(data);
-    res.json(data);
+    res.json({ id });
   } catch (e) {
     res.status(500).json({ error: "Failed to delete entry" });
   }

--- a/data/troubleshooting.json
+++ b/data/troubleshooting.json
@@ -9,7 +9,8 @@
       "Press the power button on the screen.",
       "If using a power strip, make sure it\u2019s switched on."
     ],
-    "when_to_call_support": "If the screen still doesn\u2019t turn on."
+    "when_to_call_support": "If the screen still doesn\u2019t turn on.",
+    "id": "4ba87aa3-15d7-441b-bc3a-f540227f1e6e"
   },
   {
     "system": "KDS",
@@ -21,7 +22,8 @@
       "Press the power button on the screen.",
       "If using a power strip, make sure it\u2019s switched on."
     ],
-    "when_to_call_support": "If the screen still doesn\u2019t turn on."
+    "when_to_call_support": "If the screen still doesn\u2019t turn on.",
+    "id": "3056822a-3a4a-46ef-bc43-2d9a4dd575f6"
   },
   {
     "system": "KDS",
@@ -33,7 +35,8 @@
       "Restart the KDS screen.",
       "If possible, confirm other KDS screens are working."
     ],
-    "when_to_call_support": "If the screen still says \u201cOffline\u201d after these checks."
+    "when_to_call_support": "If the screen still says \u201cOffline\u201d after these checks.",
+    "id": "a60968c6-6d53-4612-a559-f095442811f0"
   },
   {
     "system": "KDS",
@@ -44,7 +47,8 @@
       "Restart the screen (turn it off and back on).",
       "Make sure nothing is resting on the screen."
     ],
-    "when_to_call_support": "If the screen still doesn\u2019t respond to touch."
+    "when_to_call_support": "If the screen still doesn\u2019t respond to touch.",
+    "id": "1addb695-6f54-4d32-8048-50bed39780e6"
   },
   {
     "system": "KDS",
@@ -55,7 +59,8 @@
       "Make sure the KDS is connected to the internet (look for Wi-Fi or network cable).",
       "Restart the KDS app (close and reopen)."
     ],
-    "when_to_call_support": "If orders still don\u2019t appear."
+    "when_to_call_support": "If orders still don\u2019t appear.",
+    "id": "2cb5a716-8bbc-48e5-a257-cc9f3c5fbd7e"
   },
   {
     "system": "KDS",
@@ -65,7 +70,8 @@
       "Check the station name/number on the screen matches where it should be.",
       "Restart the KDS app."
     ],
-    "when_to_call_support": "If orders still show up in the wrong place."
+    "when_to_call_support": "If orders still show up in the wrong place.",
+    "id": "5234ebb7-8b59-467c-8dbc-b5e2592d0383"
   },
   {
     "system": "KDS",
@@ -76,7 +82,8 @@
       "Restart the KDS.",
       "Make sure Wi-Fi or network cable is connected and stable."
     ],
-    "when_to_call_support": "If the screen is still slow."
+    "when_to_call_support": "If the screen is still slow.",
+    "id": "fb7ce85b-fcbc-4f16-9aed-450403631511"
   },
   {
     "system": "KDS",
@@ -87,7 +94,8 @@
       "Make sure the printer is turned on and connected.",
       "Restart both the printer and the KDS."
     ],
-    "when_to_call_support": "If the tickets still don\u2019t match."
+    "when_to_call_support": "If the tickets still don\u2019t match.",
+    "id": "fe53db2a-10ee-4124-aa07-f6c00fc53ac3"
   },
   {
     "system": "KDS",
@@ -98,7 +106,8 @@
       "If that doesn\u2019t work, restart the screen.",
       "Check if there\u2019s a message about updates."
     ],
-    "when_to_call_support": "If it keeps freezing or crashing."
+    "when_to_call_support": "If it keeps freezing or crashing.",
+    "id": "e0c6af50-a595-4f61-b96b-960f59c7b93b"
   },
   {
     "system": "KDS",
@@ -109,7 +118,8 @@
       "If safe to do so, restart the Wi-Fi router or switch.",
       "Restart the KDS screen."
     ],
-    "when_to_call_support": "If there\u2019s still no internet."
+    "when_to_call_support": "If there\u2019s still no internet.",
+    "id": "741b834d-4b71-4eff-b202-d529d393e416"
   },
   {
     "system": "Kiosk",
@@ -120,7 +130,8 @@
       "Restart the kiosk (power off, wait 10 seconds, power on).",
       "Clear temporary files: if you can access Admin, go to C:\\QikServe, delete cache and shadowcache, then reboot."
     ],
-    "when_to_call_support": "If message remains after reboot and cache removal. (help.qikserve.com)"
+    "when_to_call_support": "If message remains after reboot and cache removal. (help.qikserve.com)",
+    "id": "6adccbca-6e2d-450f-a8d8-9e5d27d6a204"
   },
   {
     "system": "Kiosk",
@@ -131,7 +142,8 @@
       "Go to C:\\QikServe. Delete both cache and shadowcache.",
       "Reboot the kiosk and wait ~5 minutes. (help.qikserve.com)"
     ],
-    "when_to_call_support": "If images or menus still don\u2019t show after reboot."
+    "when_to_call_support": "If images or menus still don\u2019t show after reboot.",
+    "id": "7ca781f0-8dee-4bab-8f80-7aa6589220c2"
   },
   {
     "system": "Kiosk",
@@ -143,7 +155,8 @@
       "Run Autologon.exe, enter \u201cKioskUser\u201d and password, click \u201cEnable\u201d twice.",
       "Reboot to check if it now logs in correctly. (help.qikserve.com)"
     ],
-    "when_to_call_support": "If the kiosk still drops to sign-in screen after reboot."
+    "when_to_call_support": "If the kiosk still drops to sign-in screen after reboot.",
+    "id": "3bc07cbf-f6bd-4221-a537-75ff2b03bfc5"
   },
   {
     "system": "Kiosk",
@@ -155,7 +168,8 @@
       "Empty Recycle Bin.",
       "For certain hardware: delete older log files from e.g. FreedomPay\\Freeway Commerce Connect\\dmp. (help.qikserve.com)"
     ],
-    "when_to_call_support": "If low disk space remains or kiosk performance doesn\u2019t improve."
+    "when_to_call_support": "If low disk space remains or kiosk performance doesn\u2019t improve.",
+    "id": "ffa2c86a-d601-41cd-ad92-5c00c5efcf89"
   },
   {
     "system": "Kiosk",
@@ -166,7 +180,8 @@
       "Push an update via \u201cUpdate External Menus\u201d in QikServe Dashboard.",
       "Check the item\u2019s external ID in Dashboard matches POS records. (help.qikserve.com)"
     ],
-    "when_to_call_support": "If mistakes persist or specific items still error \u2014 report with item name, price, and PLU."
+    "when_to_call_support": "If mistakes persist or specific items still error \u2014 report with item name, price, and PLU.",
+    "id": "9bf62177-6bc0-424b-9572-c7ce9b3160fd"
   },
   {
     "system": "Kiosk",
@@ -178,7 +193,8 @@
       "Restart terminal if needed.",
       "Run a test payment (void if successful). (help.qikserve.com)"
     ],
-    "when_to_call_support": "If payments still fail or terminal stays offline."
+    "when_to_call_support": "If payments still fail or terminal stays offline.",
+    "id": "5d2ad25c-f8d3-4dd4-b2e1-a931f1158975"
   },
   {
     "system": "Kiosk",
@@ -189,7 +205,8 @@
       "Check cables are fully inserted.",
       "Restart the printer. (help.qikserve.com)"
     ],
-    "when_to_call_support": "If printer remains inactive or still doesn\u2019t print."
+    "when_to_call_support": "If printer remains inactive or still doesn\u2019t print.",
+    "id": "373d4dfa-f0e6-4434-9864-a4d4f8ba399e"
   },
   {
     "system": "Kiosk",
@@ -199,7 +216,8 @@
       "Try using the home button (if visible) to restart the app.",
       "If that doesn\u2019t work, power-cycle the kiosk. (help.qikserve.com)"
     ],
-    "when_to_call_support": "If the app keeps freezing repeatedly."
+    "when_to_call_support": "If the app keeps freezing repeatedly.",
+    "id": "513d5e38-b6bb-4610-8cfd-7a0d8fe02e2b"
   },
   {
     "system": "Kiosk",
@@ -209,7 +227,8 @@
       "Reboot the kiosk \u2014 doing this usually restores logging.",
       "Check after reboot that logs are being created again. (help.qikserve.com)"
     ],
-    "when_to_call_support": "If logging still doesn\u2019t resume after reboot."
+    "when_to_call_support": "If logging still doesn\u2019t resume after reboot.",
+    "id": "7a8167db-d358-442f-a8ae-ada8ed952e7a"
   },
   {
     "system": "POS",
@@ -220,7 +239,8 @@
       "Check that the receipt printer is the one selected on screen.",
       "Restart the POS terminal."
     ],
-    "when_to_call_support": "If printer still won\u2019t print."
+    "when_to_call_support": "If printer still won\u2019t print.",
+    "id": "a32833bd-a407-40bc-80a6-da2fec8fb90d"
   },
   {
     "system": "POS",
@@ -231,7 +251,8 @@
       "Clean paper path.",
       "Restart POS terminal."
     ],
-    "when_to_call_support": "If receipt still prints wrong."
+    "when_to_call_support": "If receipt still prints wrong.",
+    "id": "b45c32d3-1e80-42c7-ba19-2b68b023cbad"
   },
   {
     "system": "POS",
@@ -243,7 +264,8 @@
       "Restart terminal with power button.",
       "Try test payment (void if successful)."
     ],
-    "when_to_call_support": "If payments still fail or show errors."
+    "when_to_call_support": "If payments still fail or show errors.",
+    "id": "d662265d-1286-489f-9310-2f570d042dc4"
   },
   {
     "system": "POS",
@@ -254,7 +276,8 @@
       "Ensure sale is fully finished.",
       "Try \u201cNo Sale\u201d function if available."
     ],
-    "when_to_call_support": "If drawer still won\u2019t open."
+    "when_to_call_support": "If drawer still won\u2019t open.",
+    "id": "c9bbd664-b99c-486c-bc98-43fd7603e9b1"
   },
   {
     "system": "POS",
@@ -264,7 +287,8 @@
       "Remove any debris.",
       "Make sure drawer is fully closed before next sale."
     ],
-    "when_to_call_support": "If drawer keeps opening by itself or won\u2019t latch."
+    "when_to_call_support": "If drawer keeps opening by itself or won\u2019t latch.",
+    "id": "bc723af7-a1a3-4050-9f97-c69b89067bdf"
   },
   {
     "system": "POS",
@@ -274,7 +298,8 @@
       "Confirm printer is working.",
       "Check drawer cable is secure."
     ],
-    "when_to_call_support": "If printer works fine but drawer won\u2019t open."
+    "when_to_call_support": "If printer works fine but drawer won\u2019t open.",
+    "id": "119fa9d4-0adc-47c7-9529-bf0ad058d50c"
   },
   {
     "system": "POS",
@@ -285,7 +310,8 @@
       "Restart terminal.",
       "Wait 2\u20133 minutes for reconnect."
     ],
-    "when_to_call_support": "If slow after restart or affects multiple terminals."
+    "when_to_call_support": "If slow after restart or affects multiple terminals.",
+    "id": "599ef9d0-cb01-404e-9028-41f271ca4c4c"
   },
   {
     "system": "POS",
@@ -297,7 +323,8 @@
       "Inform manager immediately.",
       "Run database update"
     ],
-    "when_to_call_support": "Always contact support \u2014 pricing must be corrected in POS database."
+    "when_to_call_support": "Always contact support \u2014 pricing must be corrected in POS database.",
+    "id": "55e5b341-58bb-4ec7-b63a-e526a3a112f5"
   },
   {
     "system": "POS",
@@ -307,7 +334,8 @@
       "Check other categories or tabs to confirm it\u2019s not misplaced.",
       "If item is still missing, notify manager."
     ],
-    "when_to_call_support": "Contact support \u2014 missing items must be added in the Simphony menu setup."
+    "when_to_call_support": "Contact support \u2014 missing items must be added in the Simphony menu setup.",
+    "id": "8c63c9db-09b3-4107-a8d1-c9a2754958eb"
   },
   {
     "system": "POS",
@@ -317,7 +345,8 @@
       "Log out and back in.",
       "Check you\u2019re using the right station ID."
     ],
-    "when_to_call_support": "If login still fails or station shows wrong setup."
+    "when_to_call_support": "If login still fails or station shows wrong setup.",
+    "id": "d50acfb4-3901-44a2-9ffc-b0cf96cbc5ac"
   },
   {
     "system": "POS",
@@ -327,6 +356,7 @@
       "Log out and log in, try one more data.",
       "Run database update."
     ],
-    "when_to_call_support": "If actions fail"
+    "when_to_call_support": "If actions fail",
+    "id": "7de053bf-3891-4838-a268-63fe96ab9f4f"
   }
 ]

--- a/frontend/src/AdminPanel.jsx
+++ b/frontend/src/AdminPanel.jsx
@@ -39,8 +39,12 @@ function AdminPanel() {
     });
 
     if (res.ok) {
-      const updated = await res.json();
-      setEntries(updated);
+      const entry = await res.json();
+      setEntries(prev => (
+        editingId
+          ? prev.map(e => (e.id === entry.id ? entry : e))
+          : [...prev, entry]
+      ));
       setForm({ system: "", vendor: "", problem: "", what_to_try_first: "", when_to_call_support: "" });
       setEditingId(null);
     }
@@ -62,8 +66,8 @@ function AdminPanel() {
 
     const res = await fetch(`/api/entries/${id}`, { method: "DELETE" });
     if (res.ok) {
-      const updated = await res.json();
-      setEntries(updated);
+      const { id: removedId } = await res.json();
+      setEntries(prev => prev.filter(e => e.id !== removedId));
     }
   };
 

--- a/frontend/src/AdminPanel.jsx
+++ b/frontend/src/AdminPanel.jsx
@@ -5,7 +5,7 @@ import "./AdminPanel.css"; // optional styling
 function AdminPanel() {
   const [entries, setEntries] = useState([]);
   const [form, setForm] = useState({ system: "", vendor: "", problem: "", what_to_try_first: "", when_to_call_support: "" });
-  const [editingIndex, setEditingIndex] = useState(null);
+  const [editingId, setEditingId] = useState(null);
 
   // Fetch all entries
   useEffect(() => {
@@ -29,8 +29,8 @@ function AdminPanel() {
       when_to_call_support: form.when_to_call_support
     };
 
-    const url = editingIndex !== null ? `/api/entries/${editingIndex}` : "/api/entries";
-    const method = editingIndex !== null ? "PUT" : "POST";
+    const url = editingId ? `/api/entries/${editingId}` : "/api/entries";
+    const method = editingId ? "PUT" : "POST";
 
     const res = await fetch(url, {
       method,
@@ -42,12 +42,12 @@ function AdminPanel() {
       const updated = await res.json();
       setEntries(updated);
       setForm({ system: "", vendor: "", problem: "", what_to_try_first: "", when_to_call_support: "" });
-      setEditingIndex(null);
+      setEditingId(null);
     }
   };
 
-  const handleEdit = (entry, index) => {
-    setEditingIndex(index);
+  const handleEdit = (entry) => {
+    setEditingId(entry.id);
     setForm({
       system: entry.system,
       vendor: entry.vendor,
@@ -57,10 +57,10 @@ function AdminPanel() {
     });
   };
 
-  const handleDelete = async (index) => {
+  const handleDelete = async (id) => {
     if (!window.confirm("Delete this entry?")) return;
 
-    const res = await fetch(`/api/entries/${index}`, { method: "DELETE" });
+    const res = await fetch(`/api/entries/${id}`, { method: "DELETE" });
     if (res.ok) {
       const updated = await res.json();
       setEntries(updated);
@@ -77,22 +77,22 @@ function AdminPanel() {
         <input name="problem" value={form.problem} onChange={handleChange} placeholder="Problem" required />
         <textarea name="what_to_try_first" value={form.what_to_try_first} onChange={handleChange} placeholder="Steps (one per line)" rows={5} required />
         <textarea name="when_to_call_support" value={form.when_to_call_support} onChange={handleChange} placeholder="When to call support" rows={2} required />
-        <button type="submit">{editingIndex !== null ? "Update" : "Add"} Entry</button>
+        <button type="submit">{editingId ? "Update" : "Add"} Entry</button>
       </form>
 
       <hr />
 
       <div className="entry-list">
-        {entries.map((entry, index) => (
-          <div key={index} className="entry-block">
+        {entries.map((entry) => (
+          <div key={entry.id} className="entry-block">
             <strong>{entry.system} - {entry.problem}</strong>
             <p><em>{entry.vendor}</em></p>
             <ul>
               {entry.what_to_try_first.map((s, i) => <li key={i}>{s}</li>)}
             </ul>
             <p><strong>Support:</strong> {entry.when_to_call_support}</p>
-            <button onClick={() => handleEdit(entry, index)}>Edit</button>
-            <button onClick={() => handleDelete(index)}>Delete</button>
+            <button onClick={() => handleEdit(entry)}>Edit</button>
+            <button onClick={() => handleDelete(entry.id)}>Delete</button>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- assign UUID `id` to troubleshooting entries data
- update admin routes to manage entries by `id`
- adjust admin panel frontend to use new `id` field

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b406924490832faa4d52cbdbd73f94