### PR TITLE
Add OPENAI_API_KEY check and document env setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your-openai-api-key

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This repository hosts a small demo service that accepts user troubleshooting questions through a POST `/chat` endpoint.
 
+## Environment variables
+
+The server expects an `OPENAI_API_KEY` in its environment. Copy `.env.example` to `.env` and fill in your key:
+
+```
+OPENAI_API_KEY=your-openai-api-key
+```
+
 ## Clarification protocol
 
 The assistant may respond with a `needsClarification` object when it lacks critical system context. The structure of this response is:

--- a/troubleshooter.js
+++ b/troubleshooter.js
@@ -6,6 +6,11 @@ import { MemoryVectorStore } from "langchain/vectorstores/memory";
 
 dotenv.config();
 
+if (!process.env.OPENAI_API_KEY) {
+  console.error("Missing OPENAI_API_KEY environment variable. Please set it in your .env file.");
+  throw new Error("OPENAI_API_KEY is not defined");
+}
+
 const model = new OpenAI({
   temperature: 0.5,
   openAIApiKey: process.env.OPENAI_API_KEY,


### PR DESCRIPTION
## Summary
- verify OPENAI_API_KEY is configured before creating OpenAI client
- document required env var and provide `.env.example`

## Testing
- `node --check troubleshooter.js`
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b406b255a8832f8ac214d2bf33352c