### PR TITLE
Add react-router-dom dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",


### PR DESCRIPTION
## Summary
- add react-router-dom to frontend dependencies

## Testing
- ⚠️ `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-router-dom)*
- ⚠️ `npm run build` *(fails: Rollup failed to resolve import "react-router-dom" from src/main.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b4374d3b7c832f86d6f31027b09ab4