### PR TITLE
fix: parse JSON files as utf-8

### DIFF
--- a/troubleshooter.js
+++ b/troubleshooter.js
@@ -20,8 +20,9 @@ const model = new OpenAI({
 let vectorStore;
 
 async function loadJSON(filePath) {
-  const raw = fs.readFileSync(filePath);
-  const jsonData = JSON.parse(raw);
+  const raw = fs.readFileSync(filePath, "utf-8");
+  const rawStr = typeof raw === "string" ? raw : raw.toString("utf-8");
+  const jsonData = JSON.parse(rawStr);
 
   return jsonData.map((item) => ({
     pageContent: `Problem: ${item.problem}


### PR DESCRIPTION
## Summary
- read troubleshooting data with UTF-8 encoding
- ensure raw data is a string before JSON.parse

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b44dfe6d70832fa418ca5b26647e79