### PR TITLE
Handle missing problem metadata before matching

### DIFF
--- a/troubleshooter.js
+++ b/troubleshooter.js
@@ -65,9 +65,13 @@ export async function getTroubleshootingResponse(query, clarifiedSystem = "", se
     };
   }
 
-  const relevant = results.find(r =>
-    (r.metadata.problem === selectedProblem || query.toLowerCase().includes(r.metadata.problem))
-  ) || results[0];
+  const relevant =
+    results.find(
+      (r) =>
+        r.metadata.problem &&
+        (r.metadata.problem === selectedProblem ||
+          query.toLowerCase().includes(r.metadata.problem))
+    ) || (results[0]?.metadata.problem ? results[0] : undefined);
 
   const prompt = `You are a helpful assistant. Given the context below, provide natural, clear troubleshooting guidance to help the user.
 Context:


### PR DESCRIPTION
## Summary
- Guard against missing `metadata.problem` when searching for relevant results
- Only fallback to the first result when it has a valid problem string

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b44e127dc8832f82520c33df8050a9