### PR TITLE
Handle empty doc search results in troubleshooting response

### DIFF
--- a/troubleshooter.js
+++ b/troubleshooter.js
@@ -45,6 +45,10 @@ async function searchDocs(query) {
 export async function getTroubleshootingResponse(query, clarifiedSystem = "", selectedProblem = "") {
   const results = await searchDocs(query);
 
+  if (!results || results.length === 0) {
+    return { text: "I couldn't find relevant troubleshooting info." };
+  }
+
   const problems = results.map(r => r.metadata.problem);
   const uniqueProblems = [...new Set(problems)];
   const systems = [...new Set(results.map(r => r.metadata.system).filter(Boolean))];


### PR DESCRIPTION
## Summary
- Return a helpful message when no troubleshooting documents are found
- Skip downstream selection and prompt logic if search yields no results

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b44e091dbc832fb197154ffe2c7ff1