### PR TITLE
Handle translation errors in translator

### DIFF
--- a/translator.js
+++ b/translator.js
@@ -10,5 +10,10 @@ const translator = new OpenAI({
 
 export async function translateText(text, targetLang) {
   const prompt = `Translate the following text to ${targetLang}:\n\n${text}`;
-  return await translator.call(prompt);
+  try {
+    return await translator.call(prompt);
+  } catch (error) {
+    console.error("Translation error:", error);
+    return text;
+  }
 }


### PR DESCRIPTION
## Summary
- wrap translator call in try/catch to log errors
- fall back to original text if translation fails

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b44e8d5fd8832fb3ff2fc9c3dd8d7b