### PR TITLE
Handle translation errors in TranslationContext

### DIFF
--- a/frontend/src/TranslationContext.jsx
+++ b/frontend/src/TranslationContext.jsx
@@ -11,14 +11,28 @@ export function TranslationProvider({ children }) {
     if (target === "en") return text;
     const key = `${target}|${text}`;
     if (cacheRef.current[key]) return cacheRef.current[key];
-    const res = await fetch(`/translate`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text, targetLang: target }),
-    });
-    const data = await res.json();
-    cacheRef.current[key] = data.text;
-    return data.text;
+    try {
+      const res = await fetch(`/translate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text, targetLang: target }),
+      });
+      if (!res.ok) {
+        throw new Error(`Translation request failed: ${res.status}`);
+      }
+      const data = await res.json();
+      if (!data?.text) {
+        throw new Error("Invalid translation response");
+      }
+      cacheRef.current[key] = data.text;
+      return data.text;
+    } catch (err) {
+      console.error("Translation failed:", err);
+      if (typeof window !== "undefined" && window.alert) {
+        window.alert("Translation failed");
+      }
+      return text;
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- Wrap translation request and JSON parsing in try/catch
- Return original text and alert user on failure without caching the result

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint` *(fails: Cannot find package 'globals')*


------
https://chatgpt.com/codex/tasks/task_e_68b44e8e6594832fadcf9c77cba3d477