### PR TITLE
Fix language selector visibility

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -11,6 +11,7 @@ body {
   background-color: #ffffff;
   min-height: 100vh;
   box-sizing: border-box;
+  position: relative;
 }
 
 .app-logo {

--- a/frontend/src/LanguageSelector.css
+++ b/frontend/src/LanguageSelector.css
@@ -1,7 +1,11 @@
-.language-selector .burger {
+
+.language-selector {
   position: absolute;
   top: 10px;
   right: 10px;
+}
+
+.language-selector .burger {
   background: none;
   border: none;
   font-size: 24px;


### PR DESCRIPTION
## Summary
- Position language selector within chat container so the menu button appears
- Make chat container relative for proper overlay placement

## Testing
- `npm test` (fails: no test specified)
- `npm run lint` (fails: Cannot find module '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68b7708a57b0832fadb12f3ca6db8c8c