### PR TITLE
fix troubleshooter export and pin dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "express": "*",
-    "cors": "*",
-    "dotenv": "*",
-    "@langchain/openai": "*",
-    "langchain": "*"
+    "express": "^5.1.0",
+    "cors": "^2.8.5",
+    "dotenv": "^17.2.2",
+    "@langchain/openai": "^0.6.11",
+    "langchain": "^0.3.32"
   }
 }

--- a/troubleshooter.js
+++ b/troubleshooter.js
@@ -43,7 +43,7 @@ async function searchDocs(query) {
   return await vectorStore.similaritySearch(query, 5);
 }
 
-export async function getTroubleshootingResponse(query, clarifiedSystem = "", selectedProblem = "") {
+async function getTroubleshootingResponse(query, clarifiedSystem = "", selectedProblem = "") {
   const results = await searchDocs(query);
 
   if (!results || results.length === 0) {
@@ -87,13 +87,13 @@ User: ${query}`;
   return { text: reply };
 }
 
-export async function detectResolutionIntent(message) {
+async function detectResolutionIntent(message) {
   const prompt = `Does the following message indicate the user's problem is resolved?\n\n"${message}"\n\nAnswer yes or no.`;
   const reply = await model.call(prompt);
   return reply.toLowerCase().includes("yes");
 }
 
-export async function initStore() {
+async function initStore() {
   let allDocs = [];
 
   for (let doc of catalog) {
@@ -108,3 +108,5 @@ export async function initStore() {
     new OpenAIEmbeddings({ openAIApiKey: process.env.OPENAI_API_KEY })
   );
 }
+
+export { getTroubleshootingResponse, detectResolutionIntent, initStore };


### PR DESCRIPTION
## Summary
- export troubleshooting functions explicitly from `troubleshooter.js`
- pin express and other package versions in `package.json`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js` *(fails: OPENAI_API_KEY is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b7772c31e8832fbb29bb380d293a69