### PR TITLE
fix: pin express dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "express": "^5.1.0",
+    "express": "^4.18.2",
     "cors": "^2.8.5",
     "dotenv": "^17.2.2",
     "@langchain/openai": "^0.6.11",


### PR DESCRIPTION
## Summary
- use a stable express 4.x release to avoid module resolution errors

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b77929fef8832f94c3b8bcb1334c00