### PR TITLE
Fix LangChain model invocation

### DIFF
--- a/translator.js
+++ b/translator.js
@@ -11,7 +11,7 @@ const translator = new OpenAI({
 export async function translateText(text, targetLang) {
   const prompt = `Translate the following text to ${targetLang}:\n\n${text}`;
   try {
-    return await translator.call(prompt);
+    return await translator.invoke(prompt);
   } catch (error) {
     console.error("Translation error:", error);
     return text;
@@ -21,7 +21,7 @@ export async function translateText(text, targetLang) {
 export async function detectLanguage(text) {
   const prompt = `Detect the language of the following text. Respond with the ISO 639-1 language code only.\n\n${text}`;
   try {
-    const result = await translator.call(prompt);
+    const result = await translator.invoke(prompt);
     return result.trim().split(/\s+/)[0].toLowerCase();
   } catch (error) {
     console.error("Language detection error:", error);

--- a/troubleshooter.js
+++ b/troubleshooter.js
@@ -83,13 +83,13 @@ Context:
 ${relevant.pageContent}
 User: ${query}`;
 
-  const reply = await model.call(prompt);
+  const reply = await model.invoke(prompt);
   return { text: reply };
 }
 
 async function detectResolutionIntent(message) {
   const prompt = `Does the following message indicate the user's problem is resolved?\n\n"${message}"\n\nAnswer yes or no.`;
-  const reply = await model.call(prompt);
+  const reply = await model.invoke(prompt);
   return reply.toLowerCase().includes("yes");
 }
 


### PR DESCRIPTION
## Summary
- Use `invoke` instead of non-existent `call` when using LangChain OpenAI models in translation and troubleshooting modules

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` in `frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b786d78c6c832fb6814c7f2dc4e170