### PR TITLE
Handle optional dotenv dependency

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,11 +3,18 @@ import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { randomUUID } from 'crypto';
-import dotenv from 'dotenv';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+
+let dotenv;
+try {
+  dotenv = require('dotenv');
+  dotenv.config();
+} catch (err) {
+  console.warn('dotenv not found; skipping environment variable loading');
+}
 import { getTroubleshootingResponse, initStore, detectResolutionIntent } from './troubleshooter.js';
 import { translateText, detectLanguage } from './translator.js';
-
-dotenv.config();
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/translator.js
+++ b/translator.js
@@ -1,7 +1,4 @@
-import dotenv from "dotenv";
 import { OpenAI } from "@langchain/openai";
-
-dotenv.config();
 
 const translator = new OpenAI({
   temperature: 0,

--- a/troubleshooter.js
+++ b/troubleshooter.js
@@ -1,10 +1,7 @@
 import catalog from "./data/catalog.json" with { type: "json" };
 import fs from "fs";
-import dotenv from "dotenv";
 import { OpenAIEmbeddings, OpenAI } from "@langchain/openai";
 import { MemoryVectorStore } from "langchain/vectorstores/memory";
-
-dotenv.config();
 
 if (!process.env.OPENAI_API_KEY) {
   console.error("Missing OPENAI_API_KEY environment variable. Please set it in your .env file.");


### PR DESCRIPTION
## Summary
- Load `dotenv` only if available to prevent startup crashes
- Remove `dotenv` imports from troubleshooting and translator modules

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js` *(fails: Missing OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68b788101d4c832fbac5685cad7f50b1