### PR TITLE
refactor: load env variables via dotenv

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,18 +1,9 @@
+import 'dotenv/config';
 import http from 'http';
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { randomUUID } from 'crypto';
-import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
-
-let dotenv;
-try {
-  dotenv = require('dotenv');
-  dotenv.config();
-} catch (err) {
-  console.warn('dotenv not found; skipping environment variable loading');
-}
 import { getTroubleshootingResponse, initStore, detectResolutionIntent } from './troubleshooter.js';
 import { translateText, detectLanguage } from './translator.js';
 


### PR DESCRIPTION
## Summary
- load environment variables using `dotenv/config`
- remove manual require/dotenv block

## Testing
- `node --input-type=module -e "import('dotenv/config'); import('./troubleshooter.js').then(()=>console.log('Key loaded as', process.env.OPENAI_API_KEY))"`
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_68b7925fed68832fb1d702b1136c12b1